### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MCP Shell Server
 
 [![codecov](https://codecov.io/gh/tumf/mcp-shell-server/branch/main/graph/badge.svg)](https://codecov.io/gh/tumf/mcp-shell-server)
+[![smithery badge](https://smithery.ai/badge/mcp-shell-server)](https://smithery.ai/server/mcp-shell-server)
 
 A secure shell command execution server implementing the Model Context Protocol (MCP). This server allows remote execution of whitelisted shell commands with support for stdin input.
 
@@ -67,6 +68,14 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 ```bash
 pip install mcp-shell-server
+```
+
+### Installing via Smithery
+
+To install Shell Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-shell-server):
+
+```bash
+npx -y @smithery/cli install mcp-shell-server --client claude
 ```
 
 ## Usage


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Shell Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-shell-server

Let me know if any tweaks have to be made!