### PR TITLE
Add option to provide shell config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ pytest
 | stdin     | string     | No       | Input to be passed to the command            |
 | directory | string     | No       | Working directory for command execution       |
 | timeout   | integer    | No       | Maximum execution time in seconds             |
+| shell_config | string  | No       | Path to the shell configuration file          |
 
 ### Response Fields
 

--- a/src/mcp_shell_server/server.py
+++ b/src/mcp_shell_server/server.py
@@ -56,6 +56,10 @@ class ExecuteToolHandler:
                         "description": "Maximum execution time in seconds",
                         "minimum": 0,
                     },
+                    "shell_config": {
+                        "type": "string",
+                        "description": "Path to the shell configuration file",
+                    },
                 },
                 "required": ["command", "directory"],
             },
@@ -67,6 +71,7 @@ class ExecuteToolHandler:
         stdin = arguments.get("stdin")
         directory = arguments.get("directory", "/tmp")  # default to /tmp for safety
         timeout = arguments.get("timeout")
+        shell_config = arguments.get("shell_config")
 
         if not command:
             raise ValueError("No command provided")
@@ -84,8 +89,8 @@ class ExecuteToolHandler:
             try:
                 result = await asyncio.wait_for(
                     self.executor.execute(
-                        command, directory, stdin, None
-                    ),  # Pass None for timeout
+                        command, directory, stdin, timeout, shell_config=shell_config
+                    ),
                     timeout=timeout,
                 )
             except asyncio.TimeoutError as e:


### PR DESCRIPTION
Add an option to provide a shell config file like `~/.zshrc`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tumf/mcp-shell-server/pull/5?shareId=087d76e9-3fbb-4da8-805e-26ba6844ef32).