### PR TITLE
Add support for allowed regex patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ share/python-wheels/
 MANIFEST
 
 prompt.md
+.aider*

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
       "command": "uv",
       "args": [
         "--directory",
-        ".",
+        "/path/to/your/cloned/repository",
         "run",
         "mcp-shell-server"
       ],

--- a/README.md
+++ b/README.md
@@ -89,17 +89,7 @@ To install Shell Server for Claude Desktop automatically via [Smithery](https://
 npx -y @smithery/cli install mcp-shell-server --client claude
 ```
 
-### Configuring Regex Patterns
-
-You can allow commands using regex patterns by setting the `ALLOW_PATTERNS` environment variable. Patterns should be separated by commas.
-
-Example:
-
-```bash
-ALLOW_PATTERNS="^cmd[0-9]+$,^test.*$"
-```
-
-This configuration allows commands like `cmd123` and `testCommand`.
+## Usage
 
 ### Starting the Server
 
@@ -118,6 +108,18 @@ ALLOW_COMMANDS="ls,cat,echo"          # Basic format
 ALLOWED_COMMANDS="ls ,echo, cat"      # With spaces (using alias)
 ALLOW_COMMANDS="ls,  cat  , echo"     # Multiple spaces
 ```
+
+### Configuring Regex Patterns
+
+You can allow commands using regex patterns by setting the `ALLOW_PATTERNS` environment variable. Patterns should be separated by commas.
+
+Example:
+
+```bash
+ALLOW_PATTERNS="^cmd[0-9]+$,^test.*$"
+```
+
+This configuration allows commands like `cmd123` and `testCommand`.
 
 ### Request Format
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,17 @@ To install Shell Server for Claude Desktop automatically via [Smithery](https://
 npx -y @smithery/cli install mcp-shell-server --client claude
 ```
 
-## Usage
+### Configuring Regex Patterns
+
+You can allow commands using regex patterns by setting the `ALLOW_PATTERNS` environment variable. Patterns should be separated by commas.
+
+Example:
+
+```bash
+ALLOW_PATTERNS="^cmd[0-9]+$,^test.*$"
+```
+
+This configuration allows commands like `cmd123` and `testCommand`.
 
 ### Starting the Server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ mcp-shell-server = "mcp_shell_server:main"
 [project.optional-dependencies]
 test = [
     "pytest>=7.4.0",
+    "pytest-asyncio>=0.23.0",
     "pytest-asyncio>=0.23.0", 
     "pytest-env>=1.1.0",
     "pytest-cov>=6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ markers = [
 ]
 filterwarnings = [
     "ignore::RuntimeWarning:selectors:",
-    "ignore::pytest.PytestUnhandledCoroutineWarning:",
     "ignore::pytest.PytestUnraisableExceptionWarning:",
     "ignore::DeprecationWarning:pytest_asyncio.plugin:",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ mcp-shell-server = "mcp_shell_server:main"
 [project.optional-dependencies]
 test = [
     "pytest>=7.4.0",
-    "pytest-asyncio>=0.23.0",
     "pytest-asyncio>=0.23.0", 
     "pytest-env>=1.1.0",
     "pytest-cov>=6.0.0",

--- a/src/mcp_shell_server/command_validator.py
+++ b/src/mcp_shell_server/command_validator.py
@@ -3,7 +3,8 @@ Provides validation for shell commands and ensures they are allowed to be execut
 """
 
 import os
-from typing import Dict, List
+import re
+from typing import Dict, List, Set
 
 
 class CommandValidator:
@@ -24,12 +25,23 @@ class CommandValidator:
         commands = allow_commands + "," + allowed_commands
         return {cmd.strip() for cmd in commands.split(",") if cmd.strip()}
 
-    def get_allowed_commands(self) -> list[str]:
+    def _get_allowed_patterns(self) -> List[re.Pattern]:
+        """Get the list of allowed regex patterns from environment variables"""
+        allow_patterns = os.environ.get("ALLOW_PATTERNS", "")
+        patterns = [pattern.strip() for pattern in allow_patterns.split(",") if pattern.strip()]
+        return [re.compile(pattern) for pattern in patterns]
         """Get the list of allowed commands from environment variables"""
         return list(self._get_allowed_commands())
 
     def is_command_allowed(self, command: str) -> bool:
-        """Check if a command is in the allowed list"""
+        """Check if a command is in the allowed list or matches an allowed pattern"""
+        cmd = command.strip()
+        if cmd in self._get_allowed_commands():
+            return True
+        for pattern in self._get_allowed_patterns():
+            if pattern.match(cmd):
+                return True
+        return False
         cmd = command.strip()
         return cmd in self._get_allowed_commands()
 
@@ -92,8 +104,7 @@ class CommandValidator:
         if not command:
             raise ValueError("Empty command")
 
-        allowed_commands = self._get_allowed_commands()
-        if not allowed_commands:
+        if not self._get_allowed_commands() and not self._get_allowed_patterns():
             raise ValueError(
                 "No commands are allowed. Please set ALLOW_COMMANDS environment variable."
             )

--- a/src/mcp_shell_server/command_validator.py
+++ b/src/mcp_shell_server/command_validator.py
@@ -18,32 +18,32 @@ class CommandValidator:
         """
         pass
 
-    def _get_allowed_commands(self) -> set[str]:
+    def get_allowed_commands(self) -> set[str]:
         """Get the set of allowed commands from environment variables"""
         allow_commands = os.environ.get("ALLOW_COMMANDS", "")
         allowed_commands = os.environ.get("ALLOWED_COMMANDS", "")
         commands = allow_commands + "," + allowed_commands
         return {cmd.strip() for cmd in commands.split(",") if cmd.strip()}
 
-    def _get_allowed_patterns(self) -> List[re.Pattern]:
+    def get_allowed_patterns(self) -> List[re.Pattern]:
         """Get the list of allowed regex patterns from environment variables"""
         allow_patterns = os.environ.get("ALLOW_PATTERNS", "")
         patterns = [pattern.strip() for pattern in allow_patterns.split(",") if pattern.strip()]
         return [re.compile(pattern) for pattern in patterns]
         """Get the list of allowed commands from environment variables"""
-        return list(self._get_allowed_commands())
+        return list(self.get_allowed_commands())
 
     def is_command_allowed(self, command: str) -> bool:
         """Check if a command is in the allowed list or matches an allowed pattern"""
         cmd = command.strip()
-        if cmd in self._get_allowed_commands():
+        if cmd in self.get_allowed_commands():
             return True
-        for pattern in self._get_allowed_patterns():
+        for pattern in self.get_allowed_patterns():
             if pattern.match(cmd):
                 return True
         return False
         cmd = command.strip()
-        return cmd in self._get_allowed_commands()
+        return cmd in self.get_allowed_commands()
 
     def validate_no_shell_operators(self, cmd: str) -> None:
         """
@@ -104,7 +104,7 @@ class CommandValidator:
         if not command:
             raise ValueError("Empty command")
 
-        if not self._get_allowed_commands() and not self._get_allowed_patterns():
+        if not self.get_allowed_commands() and not self.get_allowed_patterns():
             raise ValueError(
                 "No commands are allowed. Please set ALLOW_COMMANDS environment variable."
             )

--- a/src/mcp_shell_server/command_validator.py
+++ b/src/mcp_shell_server/command_validator.py
@@ -111,5 +111,5 @@ class CommandValidator:
 
         # Clean and check the first command
         cleaned_cmd = command[0].strip()
-        if cleaned_cmd not in allowed_commands:
+        if not self.is_command_allowed(cleaned_cmd):
             raise ValueError(f"Command not allowed: {cleaned_cmd}")

--- a/src/mcp_shell_server/command_validator.py
+++ b/src/mcp_shell_server/command_validator.py
@@ -18,25 +18,27 @@ class CommandValidator:
         """
         pass
 
-    def get_allowed_commands(self) -> set[str]:
+    def _get_allowed_commands(self) -> set[str]:
         """Get the set of allowed commands from environment variables"""
         allow_commands = os.environ.get("ALLOW_COMMANDS", "")
         allowed_commands = os.environ.get("ALLOWED_COMMANDS", "")
         commands = allow_commands + "," + allowed_commands
         return {cmd.strip() for cmd in commands.split(",") if cmd.strip()}
 
+    def get_allowed_commands(self) -> list[str]:
+        """Get the list of allowed commands from environment variables"""
+        return list(self._get_allowed_commands())
+
     def get_allowed_patterns(self) -> List[re.Pattern]:
         """Get the list of allowed regex patterns from environment variables"""
         allow_patterns = os.environ.get("ALLOW_PATTERNS", "")
         patterns = [pattern.strip() for pattern in allow_patterns.split(",") if pattern.strip()]
         return [re.compile(pattern) for pattern in patterns]
-        """Get the list of allowed commands from environment variables"""
-        return list(self.get_allowed_commands())
 
     def is_command_allowed(self, command: str) -> bool:
         """Check if a command is in the allowed list or matches an allowed pattern"""
         cmd = command.strip()
-        if cmd in self.get_allowed_commands():
+        if cmd in self._get_allowed_commands():
             return True
         for pattern in self.get_allowed_patterns():
             if pattern.match(cmd):
@@ -104,7 +106,7 @@ class CommandValidator:
         if not command:
             raise ValueError("Empty command")
 
-        if not self.get_allowed_commands() and not self.get_allowed_patterns():
+        if not self._get_allowed_commands() and not self.get_allowed_patterns():
             raise ValueError(
                 "No commands are allowed. Please set ALLOW_COMMANDS environment variable."
             )

--- a/src/mcp_shell_server/server.py
+++ b/src/mcp_shell_server/server.py
@@ -30,7 +30,19 @@ class ExecuteToolHandler:
         """Get the allowed commands"""
         return self.executor.validator.get_allowed_commands()
 
+    def get_allowed_patterns(self) -> list[str]:
+        """Get the allowed regex patterns"""
+        return [pattern.pattern for pattern in self.executor.validator._get_allowed_patterns()]
+
     def get_tool_description(self) -> Tool:
+        """Get the tool description for the execute command"""
+        allowed_commands = ', '.join(self.get_allowed_commands())
+        allowed_patterns = ', '.join(self.get_allowed_patterns())
+        description = (
+            f"{self.description}\n"
+            f"Allowed commands: {allowed_commands}\n"
+            f"Allowed patterns: {allowed_patterns}"
+        )
         """Get the tool description for the execute command"""
         return Tool(
             name=self.name,

--- a/src/mcp_shell_server/server.py
+++ b/src/mcp_shell_server/server.py
@@ -32,17 +32,15 @@ class ExecuteToolHandler:
 
     def get_allowed_patterns(self) -> list[str]:
         """Get the allowed regex patterns"""
-        return [pattern.pattern for pattern in self.executor.validator._get_allowed_patterns()]
+        return [pattern.pattern for pattern in self.executor.validator.get_allowed_patterns()]
 
     def get_tool_description(self) -> Tool:
         """Get the tool description for the execute command"""
         allowed_commands = ', '.join(self.get_allowed_commands())
         allowed_patterns = ', '.join(self.get_allowed_patterns())
-        description = (
-            f"{self.description}\n"
-            f"Allowed commands: {allowed_commands}\n"
-            f"Allowed patterns: {allowed_patterns}"
-        )
+        description = f"{self.description}\n"
+        if allowed_commands != '': description += f"Allowed commands: {allowed_commands}\n"
+        if allowed_patterns != '': description += f"Allowed patterns: {allowed_patterns}"
         """Get the tool description for the execute command"""
         return Tool(
             name=self.name,

--- a/tests/test_command_validator.py
+++ b/tests/test_command_validator.py
@@ -26,7 +26,7 @@ def test_is_command_allowed_with_patterns(validator, monkeypatch):
     clear_env(monkeypatch)
     monkeypatch.setenv("ALLOW_COMMANDS", "allowed_cmd")
     monkeypatch.setenv("ALLOW_PATTERNS", "^cmd[0-9]+$")
-    
+
     assert validator.is_command_allowed("allowed_cmd")
     assert validator.is_command_allowed("cmd123")
     assert not validator.is_command_allowed("disallowed_cmd")

--- a/tests/test_command_validator.py
+++ b/tests/test_command_validator.py
@@ -22,7 +22,15 @@ def test_get_allowed_commands(validator, monkeypatch):
     assert set(validator.get_allowed_commands()) == {"cmd1", "cmd2", "cmd3", "cmd4"}
 
 
-def test_is_command_allowed(validator, monkeypatch):
+def test_is_command_allowed_with_patterns(validator, monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("ALLOW_COMMANDS", "allowed_cmd")
+    monkeypatch.setenv("ALLOW_PATTERNS", "^cmd[0-9]+$")
+    
+    assert validator.is_command_allowed("allowed_cmd")
+    assert validator.is_command_allowed("cmd123")
+    assert not validator.is_command_allowed("disallowed_cmd")
+    assert not validator.is_command_allowed("cmdabc")
     clear_env(monkeypatch)
     monkeypatch.setenv("ALLOW_COMMANDS", "allowed_cmd")
     assert validator.is_command_allowed("allowed_cmd")


### PR DESCRIPTION
This PR adds support for ALLOW_PATTERNS so in addition to command names, you can use regular expressions (regex) to define allowed commands.
Most of the code updates were actually made by aider (+gpt4o-mini), so please let me know if it needs any updates to be able to merge.