### PR TITLE
Refine the description of the directory input

### DIFF
--- a/src/mcp_shell_server/server.py
+++ b/src/mcp_shell_server/server.py
@@ -49,7 +49,7 @@ class ExecuteToolHandler:
                     },
                     "directory": {
                         "type": "string",
-                        "description": "Working directory where the command will be executed",
+                        "description": "Absolute path to a working directory where the command will be executed",
                     },
                     "timeout": {
                         "type": "integer",


### PR DESCRIPTION
An LLM may decide to pass `.` as the `directory` value, which leads to an error `ValueError: Directory must be an absolute path: .`.

This PR specifies that the `directory` has to be an absolute path to help the LLM provide an appropriate value.