### PR TITLE
Revert: Merge feature/allowed-regex-from-pr9 into main (28afd24)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Update version from tag
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,5 @@ share/python-wheels/
 MANIFEST
 
 prompt.md
-.aider*
+# Ignore serena cache
+.serena/cache/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := all
 
 test:
-	uv run pytest
+	pytest
 
 format:
 	black .
@@ -19,7 +19,7 @@ typecheck:
 	mypy src/mcp_shell_server tests
 
 coverage:
-	pytest --cov=src/mcp_shell_server tests
+	pytest --cov=src/mcp_shell_server --cov-report=xml --cov-report=term-missing tests
 
 # Run all checks required before pushing
 check:  lint typecheck

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ code ~/Library/Application\ Support/Claude/claude_desktop_config.json
       "command": "uv",
       "args": [
         "--directory",
-        "/path/to/your/cloned/repository",
+        ".",
         "run",
         "mcp-shell-server"
       ],
@@ -108,18 +108,6 @@ ALLOW_COMMANDS="ls,cat,echo"          # Basic format
 ALLOWED_COMMANDS="ls ,echo, cat"      # With spaces (using alias)
 ALLOW_COMMANDS="ls,  cat  , echo"     # Multiple spaces
 ```
-
-### Configuring Regex Patterns
-
-You can allow commands using regex patterns by setting the `ALLOW_PATTERNS` environment variable. Patterns should be separated by commas.
-
-Example:
-
-```bash
-ALLOW_PATTERNS="^cmd[0-9]+$,^test.*$"
-```
-
-This configuration allows commands like `cmd123` and `testCommand`.
 
 ### Request Format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ markers = [
 ]
 filterwarnings = [
     "ignore::RuntimeWarning:selectors:",
-    "ignore::pytest.PytestUnraisableExceptionWarning:",
     "ignore::DeprecationWarning:pytest_asyncio.plugin:",
 ]
 
@@ -104,4 +103,12 @@ exclude_lines = [
 omit = [
     "src/mcp_shell_server/__init__.py",
     "src/mcp_shell_server/version.py",
+]
+
+[dependency-groups]
+dev = [
+    "black>=23.3.0",
+    "isort>=5.12.0",
+    "mypy>=1.2.0",
+    "ruff>=0.0.262",
 ]

--- a/src/mcp_shell_server/shell_executor.py
+++ b/src/mcp_shell_server/shell_executor.py
@@ -200,7 +200,7 @@ class ShellExecutor:
                         "stderr": f"Not a directory: {directory}",
                         "execution_time": time.time() - start_time,
                     }
-            if not cleaned_command:
+            if not cleaned_command:  # pragma: no cover
                 raise ValueError("Empty command")
 
             # Initialize stdout_handle with default value
@@ -232,10 +232,10 @@ class ShellExecutor:
                     "execution_time": time.time() - start_time,
                 }
 
-            # Execute the command with interactive shell
+            # Execute the command with shell
             shell = self._get_default_shell()
             shell_cmd = self.preprocessor.create_shell_command(cmd)
-            shell_cmd = f"{shell} -i -c {shlex.quote(shell_cmd)}"
+            shell_cmd = f"{shell} -c {shlex.quote(shell_cmd)}"
 
             process = await self.process_manager.create_process(
                 shell_cmd, directory, stdout_handle=stdout_handle, envs=envs
@@ -245,7 +245,7 @@ class ShellExecutor:
                 # Send input if provided
                 stdin_bytes = stdin.encode() if stdin else None
 
-                async def communicate_with_timeout():
+                async def communicate_with_timeout():  # pragma: no cover
                     try:
                         return await process.communicate(input=stdin_bytes)
                     except Exception as e:

--- a/tests/test_command_validator.py
+++ b/tests/test_command_validator.py
@@ -1,7 +1,5 @@
 """Test cases for the CommandValidator class."""
 
-import re
-from unittest.mock import patch, MagicMock
 import pytest
 
 from mcp_shell_server.command_validator import CommandValidator
@@ -10,7 +8,6 @@ from mcp_shell_server.command_validator import CommandValidator
 def clear_env(monkeypatch):
     monkeypatch.delenv("ALLOW_COMMANDS", raising=False)
     monkeypatch.delenv("ALLOWED_COMMANDS", raising=False)
-    monkeypatch.delenv("ALLOW_PATTERNS", raising=False)
 
 
 @pytest.fixture
@@ -25,15 +22,7 @@ def test_get_allowed_commands(validator, monkeypatch):
     assert set(validator.get_allowed_commands()) == {"cmd1", "cmd2", "cmd3", "cmd4"}
 
 
-def test_is_command_allowed_with_patterns(validator, monkeypatch):
-    clear_env(monkeypatch)
-    monkeypatch.setenv("ALLOW_COMMANDS", "allowed_cmd")
-    monkeypatch.setenv("ALLOW_PATTERNS", "^cmd[0-9]+$")
-
-    assert validator.is_command_allowed("allowed_cmd")
-    assert validator.is_command_allowed("cmd123")
-    assert not validator.is_command_allowed("disallowed_cmd")
-    assert not validator.is_command_allowed("cmdabc")
+def test_is_command_allowed(validator, monkeypatch):
     clear_env(monkeypatch)
     monkeypatch.setenv("ALLOW_COMMANDS", "allowed_cmd")
     assert validator.is_command_allowed("allowed_cmd")
@@ -83,95 +72,3 @@ def test_validate_command(validator, monkeypatch):
 
     # Command allowed
     validator.validate_command(["allowed_cmd", "-arg"])  # Should not raise
-
-
-def test_pattern_cache_initialized_once(validator, monkeypatch):
-    """Test that regex patterns are compiled only once and cached"""
-    clear_env(monkeypatch)
-    monkeypatch.setenv("ALLOW_PATTERNS", "^test[0-9]+$,^cmd.*$")
-    
-    # First call should initialize cache
-    patterns1 = validator.get_allowed_patterns()
-    assert len(patterns1) == 2
-    assert validator._pattern_cache_initialized is True
-    
-    # Store reference to first patterns to compare identity
-    first_patterns = validator._compiled_patterns
-    
-    # Second call should use cached patterns
-    patterns2 = validator.get_allowed_patterns()
-    assert len(patterns2) == 2
-    
-    # Verify same objects are returned (identity check for caching)
-    assert patterns1 is patterns2
-    assert validator._compiled_patterns is first_patterns
-    
-    # Verify patterns work as expected
-    assert validator.is_command_allowed("test123")
-    assert validator.is_command_allowed("cmdtest")
-    assert not validator.is_command_allowed("invalid")
-
-
-def test_invalid_regex_pattern_handling(validator, monkeypatch, caplog):
-    """Test that invalid regex patterns are handled gracefully"""
-    clear_env(monkeypatch)
-    # Set invalid regex patterns (unclosed bracket, invalid escape)
-    monkeypatch.setenv("ALLOW_PATTERNS", "^test[,\\k,valid_pattern$")
-    
-    with caplog.at_level('WARNING'):
-        patterns = validator.get_allowed_patterns()
-        
-        # Only the valid pattern should be compiled
-        assert len(patterns) == 1
-        assert patterns[0].pattern == "valid_pattern$"
-        
-        # Check that warnings were logged for invalid patterns
-        assert "Invalid regex pattern '^test['" in caplog.text
-        assert "Invalid regex pattern '\\k'" in caplog.text
-
-
-def test_empty_patterns_environment(validator, monkeypatch):
-    """Test behavior with empty ALLOW_PATTERNS environment variable"""
-    clear_env(monkeypatch)
-    monkeypatch.setenv("ALLOW_PATTERNS", "")
-    
-    patterns = validator.get_allowed_patterns()
-    assert patterns == []
-    
-    # Should return False for any command when no patterns
-    assert not validator.is_command_allowed("any_command")
-
-
-def test_whitespace_in_patterns(validator, monkeypatch):
-    """Test that whitespace is handled properly in patterns"""
-    clear_env(monkeypatch)
-    monkeypatch.setenv("ALLOW_PATTERNS", "  ^test$  , , ^valid.*$ ")
-    
-    patterns = validator.get_allowed_patterns()
-    assert len(patterns) == 2
-    
-    # Test that patterns work correctly
-    assert validator.is_command_allowed("test")
-    assert validator.is_command_allowed("validcommand")
-    assert not validator.is_command_allowed("invalid")
-
-
-def test_cache_persistence_across_calls(validator, monkeypatch):
-    """Test that the cache persists across multiple method calls"""
-    clear_env(monkeypatch)
-    monkeypatch.setenv("ALLOW_PATTERNS", "^cache_test$")
-    
-    # First call initializes cache
-    result1 = validator.is_command_allowed("cache_test")
-    assert result1 is True
-    
-    # Subsequent calls should use cached patterns
-    result2 = validator.is_command_allowed("cache_test")
-    assert result2 is True
-    
-    result3 = validator.is_command_allowed("other_command")
-    assert result3 is False
-    
-    # Verify cache was initialized only once
-    assert validator._pattern_cache_initialized is True
-    assert len(validator._compiled_patterns) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -336,6 +336,14 @@ test = [
     { name = "pytest-mock" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
+    { name = "isort" },
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "asyncio", specifier = ">=3.4.3" },
@@ -352,6 +360,14 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.262" },
 ]
 provides-extras = ["dev", "test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=23.3.0" },
+    { name = "isort", specifier = ">=5.12.0" },
+    { name = "mypy", specifier = ">=1.2.0" },
+    { name = "ruff", specifier = ">=0.0.262" },
+]
 
 [[package]]
 name = "mypy"


### PR DESCRIPTION
This PR reverts the merge commit 28afd24 to allow fixes and re-application.

**What this PR does:**
- Reverts merge commit 28afd24a6f2eea4ab25c1112c4e0fd608bea2a24
- Undoes the merge of feature/allowed-regex-from-pr9 into main
- Allows for fixes to be applied and the feature to be re-merged later

**Reverted changes:**
- Removes regex pattern caching and error handling from the allowed-regex feature
- Restores main branch to state before the problematic merge

**Next steps:**
- Apply necessary fixes to the feature branch
- Re-apply the feature with proper implementation