### PR TITLE
Filter shell job-control warnings from stderr

### DIFF
--- a/src/mcp_shell_server/server.py
+++ b/src/mcp_shell_server/server.py
@@ -17,6 +17,11 @@ logger = logging.getLogger("mcp-shell-server")
 
 app: Server = Server("mcp-shell-server")
 
+IGNORED_STDERR_SUBSTRINGS = (
+    "cannot set terminal process group",
+    "no job control in this shell",
+)
+
 
 class ExecuteToolHandler:
     """Handler for shell command execution"""
@@ -112,10 +117,20 @@ class ExecuteToolHandler:
             if result.get("stdout"):
                 content.append(TextContent(type="text", text=result["stdout"]))
 
-            # Add stderr if present (filter out specific messages)
+            # Add stderr if present, excluding known non-actionable shell warnings.
             stderr = result.get("stderr")
-            if stderr and "cannot set terminal process group" not in stderr:
-                content.append(TextContent(type="text", text=stderr))
+            if stderr:
+                filtered_stderr_lines = [
+                    line
+                    for line in stderr.splitlines()
+                    if not any(
+                        ignored_substring in line
+                        for ignored_substring in IGNORED_STDERR_SUBSTRINGS
+                    )
+                ]
+                filtered_stderr = "\n".join(filtered_stderr_lines).strip()
+                if filtered_stderr:
+                    content.append(TextContent(type="text", text=filtered_stderr))
 
         except asyncio.TimeoutError as e:
             raise ValueError(f"Command timed out after {timeout} seconds") from e

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -340,6 +340,58 @@ async def test_call_tool_with_stderr(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_call_tool_filters_known_shell_warnings(monkeypatch):
+    """Known shell startup warnings should be filtered from stderr output."""
+
+    async def mock_create_subprocess_shell(
+        cmd, stdin=None, stdout=None, stderr=None, env=None, cwd=None
+    ):
+        return MockProcess(
+            stdout=b"",
+            stderr=(
+                b"bash: cannot set terminal process group (1234): Inappropriate ioctl for device\n"
+                b"bash: no job control in this shell\n"
+            ),
+            returncode=0,
+        )
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_shell", mock_create_subprocess_shell
+    )
+    monkeypatch.setenv("ALLOW_COMMANDS", "echo")
+
+    result = await call_tool("shell_execute", {"command": ["echo", "hello"]})
+    assert len(result) == 0
+
+
+@pytest.mark.asyncio
+async def test_call_tool_filters_only_warning_lines(monkeypatch):
+    """Warning lines are removed while non-warning stderr content is preserved."""
+
+    async def mock_create_subprocess_shell(
+        cmd, stdin=None, stdout=None, stderr=None, env=None, cwd=None
+    ):
+        return MockProcess(
+            stdout=b"",
+            stderr=(
+                b"bash: cannot set terminal process group (1234): Inappropriate ioctl for device\n"
+                b"real error line\n"
+            ),
+            returncode=1,
+        )
+
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_shell", mock_create_subprocess_shell
+    )
+    monkeypatch.setenv("ALLOW_COMMANDS", "echo")
+
+    result = await call_tool("shell_execute", {"command": ["echo", "hello"]})
+    assert len(result) == 1
+    stderr_content = next((c for c in result if c.text == "real error line"), None)
+    assert stderr_content is not None
+
+
+@pytest.mark.asyncio
 async def test_main_server(mocker):
     """Test the main server function"""
     # Mock the stdio_server


### PR DESCRIPTION
## Issue

  Some command runs emit shell startup warnings on stderr:

  - cannot set terminal process group
  - no job control in this shell

  These warnings are noisy and can appear in tool output.

  ## Change

  Updated server-side stderr handling to filter those warning lines before returning output.

  The filtering is line-based, so only matching warning lines are removed and other stderr content is preserved.

  ## Validation

  - Added test for warning-only stderr to confirm warnings are suppressed.
  - Added test for mixed stderr (warning + real error) to confirm real errors are still returned.