### PR TITLE
docs: add MCP Find directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/tumf/mcp-shell-server/branch/main/graph/badge.svg)](https://codecov.io/gh/tumf/mcp-shell-server)
 [![smithery badge](https://smithery.ai/badge/mcp-shell-server)](https://smithery.ai/server/mcp-shell-server)
-
+[![Listed on MCP Find](https://img.shields.io/badge/MCP_Find-Listed-blue)](https://mcp-find.org/tools/mcp-shell-server)
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/tumf-mcp-shell-server-badge.png)](https://mseep.ai/app/tumf-mcp-shell-server)
 
 A secure shell command execution server implementing the Model Context Protocol (MCP). This server allows remote execution of whitelisted shell commands with support for stdin input.


### PR DESCRIPTION
Hi 👋

mcp-shell-server is featured on [MCP Find](https://mcp-find.org/tools/mcp-shell-server), 
a curated directory for the MCP ecosystem. The listing includes an 
editorial review, evidence profile, trust signals, and related 
tool comparisons.

This PR adds a small badge linking to the listing page.

**What MCP Find provides for mcp-shell-server:**
- Dedicated tool profile with editorial review
- Trust/risk signal assessment  
- Comparison pages with related tools
- Integration into topic hubs
- Related workflow and learning guide links

Feel free to merge, modify placement, or close if you'd prefer 
not to include it. No pressure at all!

Preview: [mcp-shell-server on MCP Find](https://mcp-find.org/tools/mcp-shell-server)