### PR TITLE
fix: harden command argument validation

### DIFF
--- a/src/mcp_shell_server/command_validator.py
+++ b/src/mcp_shell_server/command_validator.py
@@ -98,14 +98,32 @@ class CommandValidator:
             index += 1
         return values
 
-    def _is_git_alias_exec_config(self, config_value: str) -> bool:
-        alias_index = config_value.lower().find("alias.")
-        if alias_index == -1:
-            return False
-        return config_value.find("=!", alias_index + len("alias.")) != -1
+    def _is_git_dangerous_config(self, config_value: str) -> bool:
+        compact = re.sub(r"\s+", "", config_value)
+        return bool(
+            re.search(r"(?i)(?:^|[.\s])alias\.[^=\s]+\s*=\s*!", config_value)
+            or re.search(r"(?i)^core\.(pager|sshcommand)=", compact)
+        )
+
+    def _has_option_value(self, args: List[str], option: str, predicate) -> bool:
+        for index, arg in enumerate(args):
+            if arg == option and index + 1 < len(args) and predicate(args[index + 1]):
+                return True
+            if arg.startswith(f"{option}=") and predicate(arg.split("=", 1)[1]):
+                return True
+        return False
+
+    def _has_any_option(self, args: List[str], options: set[str]) -> bool:
+        return any(
+            arg in options or any(arg.startswith(f"{option}=") for option in options)
+            for arg in args
+        )
+
+    def _has_short_option_prefix(self, args: List[str], option: str) -> bool:
+        return any(arg == option or arg.startswith(option) for arg in args)
 
     def _validate_default_argument_policy(self, command: List[str]) -> None:
-        cmd = self._validate_command_name_form(command[0])
+        cmd = os.path.basename(self._validate_command_name_form(command[0]))
         args = command[1:]
         if cmd in DANGEROUS_COMMANDS:
             raise ValueError(f"Command rejected by default security policy: {cmd}")
@@ -113,26 +131,33 @@ class CommandValidator:
         if cmd == "find" and any(arg in {"-exec", "-execdir"} for arg in args):
             raise ValueError("Command rejected by default security policy: find -exec")
 
-        if cmd == "awk" and any("system(" in arg.replace(" ", "") for arg in args):
-            raise ValueError(
-                "Command rejected by default security policy: awk system()"
-            )
-
-        if cmd == "tar" and any(
-            arg == "--checkpoint-action=exec"
-            or arg.startswith("--checkpoint-action=exec=")
+        if cmd == "awk" and any(
+            "system(" in (compact := re.sub(r"\s+", "", arg)) or "|" in compact
             for arg in args
         ):
             raise ValueError(
-                "Command rejected by default security policy: tar checkpoint exec"
+                "Command rejected by default security policy: awk command execution"
+            )
+
+        if cmd == "tar" and (
+            self._has_option_value(
+                args, "--checkpoint-action", lambda value: value.startswith("exec=")
+            )
+            or self._has_any_option(
+                args, {"--to-command", "--use-compress-program", "--rsh-command"}
+            )
+            or self._has_short_option_prefix(args, "-I")
+        ):
+            raise ValueError(
+                "Command rejected by default security policy: tar command execution option"
             )
 
         if cmd == "git" and any(
-            self._is_git_alias_exec_config(config_value)
+            self._is_git_dangerous_config(config_value)
             for config_value in self._git_config_values(args)
         ):
             raise ValueError(
-                "Command rejected by default security policy: git alias exec"
+                "Command rejected by default security policy: git command execution config"
             )
 
     def validate_pipeline(self, commands: List[str]) -> Dict[str, str]:

--- a/tests/test_command_validator.py
+++ b/tests/test_command_validator.py
@@ -106,14 +106,18 @@ def test_default_dangerous_exec_vectors_are_rejected(validator, monkeypatch):
     )
 
     dangerous_commands = [
-        ["find", ".", "-exec", "sh", "-c", "echo pwned", ";"],
-        ["sh", "-c", "echo pwned"],
-        ["bash", "-c", "echo pwned"],
-        ["python", "-c", "print('pwned')"],
-        ["python3", "-c", "print('pwned')"],
+        ["find", ".", "-exec", "sh", "-c", "id", ";"],
+        ["sh", "-c", "id"],
+        ["bash", "-c", "id"],
+        ["python", "-c", "print(1)"],
+        ["python3", "script.py"],
         ["awk", 'BEGIN { system("id") }'],
+        ["awk", 'BEGIN { system\t("id") }'],
+        ["awk", 'BEGIN { print "id" | "/bin/sh" }'],
         ["tar", "--checkpoint-action=exec=sh shell.sh"],
-        ["xargs", "sh", "-c", "echo pwned"],
+        ["tar", "-I/bin/sh", "-cf", "x.tar", "file"],
+        ["tar", "--rsh-command=/bin/sh -c id", "-cf", "host:/tmp/x", "file"],
+        ["xargs", "sh"],
         ["env"],
     ]
 
@@ -139,18 +143,24 @@ def test_dangerous_exec_capable_vectors_are_rejected(validator, monkeypatch):
     clear_env(monkeypatch)
     monkeypatch.setenv(
         "ALLOW_COMMANDS",
-        "find,sh,bash,python,awk,tar,xargs,env,node,perl,ruby",
+        "/usr/bin/find,/bin/sh,/bin/bash,/usr/bin/python,/usr/bin/awk,/usr/bin/tar,/usr/bin/xargs,/usr/bin/env,node,perl,ruby",
     )
 
     dangerous_commands = [
-        (["find", ".", "-exec", "sh", "-c", "id", ";"], "find -exec"),
-        (["sh", "-c", "id"], "sh"),
-        (["bash", "-c", "id"], "bash"),
-        (["python", "-c", "print(1)"], "python"),
-        (["awk", 'BEGIN { system("id") }'], "awk system"),
-        (["tar", "--checkpoint-action=exec=sh shell.sh"], "tar checkpoint"),
-        (["xargs", "sh"], "xargs"),
-        (["env"], "env"),
+        (["/usr/bin/find", ".", "-exec", "sh", "-c", "id", ";"], "find -exec"),
+        (["/bin/sh", "-c", "id"], "sh"),
+        (["/bin/bash", "-c", "id"], "bash"),
+        (["/usr/bin/python", "-c", "print(1)"], "python"),
+        (["/usr/bin/awk", 'BEGIN { system("id") }'], "awk"),
+        (["/usr/bin/awk", 'BEGIN { "id" | getline out; print out }'], "awk"),
+        (["/usr/bin/tar", "--checkpoint-action=exec=sh shell.sh"], "tar command execution"),
+        (["/usr/bin/tar", "--checkpoint-action", "exec=sh shell.sh"], "tar command execution"),
+        (["/usr/bin/tar", "--to-command=sh shell.sh"], "tar command execution"),
+        (["/usr/bin/tar", "--use-compress-program=sh shell.sh"], "tar command execution"),
+        (["/usr/bin/tar", "-I/bin/sh"], "tar command execution"),
+        (["/usr/bin/tar", "--rsh-command=/bin/sh -c id"], "tar command execution"),
+        (["/usr/bin/xargs", "sh"], "xargs"),
+        (["/usr/bin/env"], "env"),
     ]
 
     for argv, expected in dangerous_commands:
@@ -167,10 +177,25 @@ def test_git_alias_exec_bypass_is_rejected(validator, monkeypatch):
         ["git", '-calias.pwn=!sh -c "touch marker"', "pwn"],
         ["git", "-c", "url.alias.example=!not-an-exec-alias", "status"],
         ["git", "-c", 'Alias.pwn=!sh -c "touch marker"', "pwn"],
+        ["git", "-c", 'alias.pwn = !sh -c "touch marker"', "pwn"],
     ]
 
     for command in dangerous_commands:
-        with pytest.raises(ValueError, match="git alias exec"):
+        with pytest.raises(ValueError, match="git command execution config"):
+            validator.validate_command(command)
+
+
+def test_git_exec_capable_configs_are_rejected(validator, monkeypatch):
+    clear_env(monkeypatch)
+    monkeypatch.setenv("ALLOW_COMMANDS", "/usr/bin/git")
+
+    dangerous_commands = [
+        ["/usr/bin/git", "-c", "core.pager=!sh -c id", "log"],
+        ["/usr/bin/git", "-c", "core.sshCommand=sh -c id", "ls-remote", "ssh://x/y"],
+    ]
+
+    for command in dangerous_commands:
+        with pytest.raises(ValueError, match="git command execution config"):
             validator.validate_command(command)
 
 

--- a/tests/test_command_validator.py
+++ b/tests/test_command_validator.py
@@ -153,10 +153,19 @@ def test_dangerous_exec_capable_vectors_are_rejected(validator, monkeypatch):
         (["/usr/bin/python", "-c", "print(1)"], "python"),
         (["/usr/bin/awk", 'BEGIN { system("id") }'], "awk"),
         (["/usr/bin/awk", 'BEGIN { "id" | getline out; print out }'], "awk"),
-        (["/usr/bin/tar", "--checkpoint-action=exec=sh shell.sh"], "tar command execution"),
-        (["/usr/bin/tar", "--checkpoint-action", "exec=sh shell.sh"], "tar command execution"),
+        (
+            ["/usr/bin/tar", "--checkpoint-action=exec=sh shell.sh"],
+            "tar command execution",
+        ),
+        (
+            ["/usr/bin/tar", "--checkpoint-action", "exec=sh shell.sh"],
+            "tar command execution",
+        ),
         (["/usr/bin/tar", "--to-command=sh shell.sh"], "tar command execution"),
-        (["/usr/bin/tar", "--use-compress-program=sh shell.sh"], "tar command execution"),
+        (
+            ["/usr/bin/tar", "--use-compress-program=sh shell.sh"],
+            "tar command execution",
+        ),
         (["/usr/bin/tar", "-I/bin/sh"], "tar command execution"),
         (["/usr/bin/tar", "--rsh-command=/bin/sh -c id"], "tar command execution"),
         (["/usr/bin/xargs", "sh"], "xargs"),

--- a/tests/test_shell_executor.py
+++ b/tests/test_shell_executor.py
@@ -38,7 +38,7 @@ async def test_git_alias_exec_poc_is_rejected_without_side_effect(
         )
 
     assert result["status"] == 1
-    assert "git alias exec" in result["error"]
+    assert "git command execution config" in result["error"]
     assert not marker.exists()
     assert any(
         getattr(record, "audit", {}).get("result_type") == "rejected"


### PR DESCRIPTION
## Summary

Fixes argument-hardening gaps related to GHSA-gvwf-5g64-3vvw.

- Normalize command basename before default dangerous-argument policy checks, so absolute-path allowlist entries cannot bypass hardening.
- Reject additional tar command-execution vectors:
  - `--checkpoint-action exec=...`
  - `--to-command`
  - `--use-compress-program`
  - `--rsh-command`
  - `-I...`
- Reject additional awk execution vectors:
  - whitespace-obfuscated `system(...)`
  - pipeline execution forms containing `|`
- Reject additional git execution-capable config:
  - alias exec forms with whitespace around `=`
  - `core.pager=...`
  - `core.sshCommand=...`

## Tests

```text
uv run --no-sync pytest
173 passed, 1 warning in 8.37s
```

The warning is an existing asyncio subprocess cleanup warning unrelated to this change.
