### PR TITLE
Harden Docker runtime to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ COPY . .
 # Install the project's dependencies
 RUN --mount=type=cache,target=/root/.cache/uv pip install .
 
+RUN useradd --create-home --shell /usr/sbin/nologin mcp
+USER mcp
+
 # Set environment variables
 ENV ALLOW_COMMANDS="ls,cat,pwd,grep,wc,touch,find"
 


### PR DESCRIPTION
Hi maintainers,

ProofLayer found that this Docker image currently starts as root. This PR adds an explicit non-root runtime user while leaving the existing build and entrypoint unchanged.

Why this helps:
- reduces container breakout blast radius if the MCP server or one of its dependencies is compromised
- follows the least-privilege default expected for published MCP server containers
- keeps the patch intentionally small and easy to review

Validation:
- ProofLayer Dockerfile scan: run-as-root warning removed; uv run pytest currently fails before tests with ModuleNotFoundError: mcp_shell_server
- Docker build could not be run from my local environment because the Docker daemon socket was unavailable.

Found with ProofLayer, an open-source scanner for AI agent and MCP security.
